### PR TITLE
fix: Resolved an error with overlapping Japanese words

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ WORKDIR /app
 
 RUN apt-get update -y
 
+# NOTE: 日本語フォントがないと日本語が重なることがあるので追加
+RUN apt install --no-install-recommends -y default-jre graphviz fonts-ipafont
+
 RUN <<EOF bash -ex
 apt-get install -y --no-install-recommends libxext6 libxrender1 libxtst6 libxi6
 rm -rf /var/lib/lists

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [ENVIRONMENT](#environment)
 - [PREPARING](#preparing)
 - [HOW TO USE](#how-to-use)
+- [ERROR LOG](#error-log)
 
 ---
 
@@ -89,3 +90,11 @@ gradle clean
 ```
 
 ---
+
+## ERROR LOG
+
+### PlantUMLの日本語が重なる
+
+Dev Containerに日本語フォントが入っていないのが原因。[素晴らしいQiita](https://qiita.com/yomon8/items/a3e016b7ffc3e4fbb7e5)
+
+

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,5 +1,11 @@
 = The test asciidoc
+// 出力されるpdfにVersion unspecifiedにならないようにversionを指定
+:revnumber: 0.1.0
+:sectnums: // 見出しに番号をつける
 :asciidoc-guide-gradle-plugin: https://asciidoctor.github.io/asciidoctor-gradle-plugin/master/
+// 目次
+:toc: left
+:toc-title: 目次
 
 Asciidocを使ってみる。
 

--- a/src/docs/diagram/pu/plantuml_test.pu
+++ b/src/docs/diagram/pu/plantuml_test.pu
@@ -1,4 +1,16 @@
 @startuml conversation
 title PlantUML test
-Bob->Alice : Hello!
+box #DodgerBlue
+participant "ユーザ\n端末\n" as ユーザ端末
+end box
+
+box #LightBlue
+participant "サーバ" as サーバ
+
+ユーザ端末 -> サーバ : ログイン試行
+
+opt 該当ユーザが存在しない
+  ユーザ端末 <- サーバ : ID，パスワードが間違っている旨を返して終了
+end
+
 @enduml


### PR DESCRIPTION
plantUMLで日本語が重なるエラーを日本語フォントを入れることで修正。
ドキュメントにversionを付加